### PR TITLE
PODS-462: Implement Company Registration Number page

### DIFF
--- a/app/assets/stylesheets/partials/heading.scss
+++ b/app/assets/stylesheets/partials/heading.scss
@@ -1,0 +1,69 @@
+
+.page-header {
+  clear: both;
+  display: table;
+  margin-bottom: 0.9375em;
+  margin-top: 1.875em;
+  padding-top: 8px;
+}
+
+@media (min-width: 641px) {
+  .page-header {
+    margin-bottom: 1.25em;
+    margin-top: 1.875em;
+  }
+}
+
+.page-header .heading-xlarge {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 700;
+  text-transform: none;
+  font-size: 32px;
+  line-height: 1.09375;
+  margin-bottom: 0;
+  margin-top: 0.25em;
+}
+
+@media (min-width: 641px) {
+  .page-header .heading-xlarge {
+    font-size: 48px;
+    line-height: 1.04167;
+  }
+}
+
+@media (min-width: 641px) {
+  .page-header .heading-xlarge {
+    margin-top: 0.125em;
+  }
+}
+
+.page-header .heading-secondary {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 20px;
+  line-height: 1.11111;
+  display: block;
+  padding-top: 8px;
+  padding-bottom: 7px;
+  color: #6f777b;
+  display: table-header-group;
+}
+
+@media (min-width: 641px) {
+  .page-header .heading-secondary {
+    font-size: 27px;
+    line-height: 1.11111;
+  }
+}
+
+@media (min-width: 641px) {
+  .page-header .heading-secondary {
+    padding-top: 4px;
+    padding-bottom: 6px;
+  }
+}
+
+.autocomplete__option > strong {
+  pointer-events: auto;
+}

--- a/app/assets/stylesheets/pensionadministratorfrontend-app.scss
+++ b/app/assets/stylesheets/pensionadministratorfrontend-app.scss
@@ -8,3 +8,5 @@
 @import 'partials/_utilities';
 
 @import 'partials/_shame';
+
+@import 'partials/heading';

--- a/app/controllers/company/CompanyUniqueTaxReferenceController.scala
+++ b/app/controllers/company/CompanyUniqueTaxReferenceController.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.company
+
+import javax.inject.Inject
+
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import connectors.DataCacheConnector
+import controllers.actions._
+import config.FrontendAppConfig
+import forms.company.CompanyUniqueTaxReferenceFormProvider
+import identifiers.company.CompanyUniqueTaxReferenceId
+import models.Mode
+import utils.{Navigator, UserAnswers}
+import views.html.company.companyUniqueTaxReference
+
+import scala.concurrent.Future
+
+class CompanyUniqueTaxReferenceController @Inject() (
+                                        appConfig: FrontendAppConfig,
+                                        override val messagesApi: MessagesApi,
+                                        dataCacheConnector: DataCacheConnector,
+                                        navigator: Navigator,
+                                        authenticate: AuthAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: CompanyUniqueTaxReferenceFormProvider
+                                      ) extends FrontendController with I18nSupport {
+
+  private val form = formProvider()
+
+  def onPageLoad(mode: Mode) = (authenticate andThen getData andThen requireData) {
+    implicit request =>
+      val preparedForm = request.userAnswers.get(CompanyUniqueTaxReferenceId) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+      Ok(companyUniqueTaxReference(appConfig, preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (authenticate andThen getData andThen requireData).async {
+    implicit request =>
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(companyUniqueTaxReference(appConfig, formWithErrors, mode))),
+        (value) =>
+          dataCacheConnector.save(request.externalId, CompanyUniqueTaxReferenceId, value).map(cacheMap =>
+            Redirect(navigator.nextPage(CompanyUniqueTaxReferenceId, mode)(new UserAnswers(cacheMap))))
+    )
+  }
+}

--- a/app/controllers/register/company/CompanyRegistrationNumberController.scala
+++ b/app/controllers/register/company/CompanyRegistrationNumberController.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.register.company
+
+import javax.inject.Inject
+
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import connectors.DataCacheConnector
+import controllers.actions._
+import config.FrontendAppConfig
+import forms.register.company.CompanyRegistrationNumberFormProvider
+import identifiers.register.company.CompanyRegistrationNumberId
+import models.Mode
+import utils.{Navigator, UserAnswers}
+import views.html.register.company.companyRegistrationNumber
+
+import scala.concurrent.Future
+
+class CompanyRegistrationNumberController @Inject() (
+                                        appConfig: FrontendAppConfig,
+                                        override val messagesApi: MessagesApi,
+                                        dataCacheConnector: DataCacheConnector,
+                                        navigator: Navigator,
+                                        authenticate: AuthAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: CompanyRegistrationNumberFormProvider
+                                      ) extends FrontendController with I18nSupport {
+
+  private val form = formProvider()
+
+  def onPageLoad(mode: Mode) = (authenticate andThen getData andThen requireData) {
+    implicit request =>
+      val preparedForm = request.userAnswers.get(CompanyRegistrationNumberId) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+      Ok(companyRegistrationNumber(appConfig, preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (authenticate andThen getData andThen requireData).async {
+    implicit request =>
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(companyRegistrationNumber(appConfig, formWithErrors, mode))),
+        (value) =>
+          dataCacheConnector.save(request.externalId, CompanyRegistrationNumberId, value).map(cacheMap =>
+            Redirect(navigator.nextPage(CompanyRegistrationNumberId, mode)(new UserAnswers(cacheMap))))
+    )
+  }
+}

--- a/app/forms/company/CompanyUniqueTaxReferenceFormProvider.scala
+++ b/app/forms/company/CompanyUniqueTaxReferenceFormProvider.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,16 +12,20 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@(headingKey: String, headingSize: String = "heading-xlarge", secondaryHeaderKey: Option[String] = None)(implicit messages: Messages)
+package forms.company
 
-<header class="page-header">
- <h1 class="@headingSize">@messages(headingKey)</h1>
- @secondaryHeaderKey.map { secHeader =>
- <p class="heading-secondary"><span class="visuallyhidden">This section is: </span>@messages(secHeader)</p>
- }
-</header>
+import forms.FormErrorHelper
+import forms.mappings.Mappings
+import javax.inject.Inject
+import play.api.data.Form
 
+class CompanyUniqueTaxReferenceFormProvider @Inject() extends FormErrorHelper with Mappings {
 
-
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("companyUniqueTaxReference.error.required")
+        .verifying(maxLength(10, "companyUniqueTaxReference.error.length"))
+    )
+}

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -20,6 +20,8 @@ import play.api.data.validation.{Constraint, Invalid, Valid}
 
 trait Constraints {
 
+  val crn = """^\d{7}|[a-zA-Z]{1,2}\d{6}$"""
+
   protected def firstError[A](constraints: Constraint[A]*): Constraint[A] =
     Constraint {
       input =>
@@ -83,4 +85,11 @@ trait Constraints {
       case _ =>
         Invalid(errorKey, maximum)
     }
+
+  protected def companyRegistrationNumber(errorKey: String): Constraint[String] = {
+
+    regexp(crn, errorKey)
+
+  }
+
 }

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -20,7 +20,7 @@ import play.api.data.validation.{Constraint, Invalid, Valid}
 
 trait Constraints {
 
-  val crn = """^\d{7}|[a-zA-Z]{1,2}\d{6}$"""
+  protected val crn = """^\d{7}|[a-zA-Z]{1,2}\d{6}$"""
 
   protected def firstError[A](constraints: Constraint[A]*): Constraint[A] =
     Constraint {

--- a/app/forms/register/company/CompanyRegistrationNumberFormProvider.scala
+++ b/app/forms/register/company/CompanyRegistrationNumberFormProvider.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,16 +12,23 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@(headingKey: String, headingSize: String = "heading-xlarge", secondaryHeaderKey: Option[String] = None)(implicit messages: Messages)
+package forms.register.company
 
-<header class="page-header">
- <h1 class="@headingSize">@messages(headingKey)</h1>
- @secondaryHeaderKey.map { secHeader =>
- <p class="heading-secondary"><span class="visuallyhidden">This section is: </span>@messages(secHeader)</p>
- }
-</header>
+import forms.FormErrorHelper
+import forms.mappings.Mappings
+import javax.inject.Inject
+import play.api.data.Form
 
+class CompanyRegistrationNumberFormProvider @Inject() extends FormErrorHelper with Mappings {
 
-
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("companyRegistrationNumber.error.required")
+        .verifying(firstError(
+          maxLength(8, "companyRegistrationNumber.error.length"),
+          companyRegistrationNumber("companyRegistrationNumber.error.invalid")
+        ))
+    )
+}

--- a/app/identifiers/company/CompanyUniqueTaxReferenceId.scala
+++ b/app/identifiers/company/CompanyUniqueTaxReferenceId.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,16 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@(headingKey: String, headingSize: String = "heading-xlarge", secondaryHeaderKey: Option[String] = None)(implicit messages: Messages)
+package identifiers.company
 
-<header class="page-header">
- <h1 class="@headingSize">@messages(headingKey)</h1>
- @secondaryHeaderKey.map { secHeader =>
- <p class="heading-secondary"><span class="visuallyhidden">This section is: </span>@messages(secHeader)</p>
- }
-</header>
+import identifiers._
 
-
-
+case object CompanyUniqueTaxReferenceId extends TypedIdentifier[String] {
+  override def toString: String = "companyUniqueTaxReference"
+}

--- a/app/identifiers/register/company/CompanyRegistrationNumberId.scala
+++ b/app/identifiers/register/company/CompanyRegistrationNumberId.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,16 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@(headingKey: String, headingSize: String = "heading-xlarge", secondaryHeaderKey: Option[String] = None)(implicit messages: Messages)
+package identifiers.register.company
 
-<header class="page-header">
- <h1 class="@headingSize">@messages(headingKey)</h1>
- @secondaryHeaderKey.map { secHeader =>
- <p class="heading-secondary"><span class="visuallyhidden">This section is: </span>@messages(secHeader)</p>
- }
-</header>
+import identifiers._
 
-
-
+case object CompanyRegistrationNumberId extends TypedIdentifier[String] {
+  override def toString: String = "companyRegistrationNumber"
+}

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -21,4 +21,12 @@ import models.CheckMode
 import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
+
+  def companyUniqueTaxReference: Option[AnswerRow] = userAnswers.get(identifiers.company.CompanyUniqueTaxReferenceId) map {
+    x => AnswerRow("companyUniqueTaxReference.checkYourAnswersLabel", s"$x", false, controllers.company.routes.CompanyUniqueTaxReferenceController.onPageLoad(CheckMode).url)
+  }
+
+  def companyRegistrationNumber: Option[AnswerRow] = userAnswers.get(identifiers.register.company.CompanyRegistrationNumberId) map {
+    x => AnswerRow("companyRegistrationNumber.checkYourAnswersLabel", s"$x", false, controllers.register.company.routes.CompanyRegistrationNumberController.onPageLoad(CheckMode).url)
+  }
 }

--- a/app/views/company/companyUniqueTaxReference.scala.html
+++ b/app/views/company/companyUniqueTaxReference.scala.html
@@ -1,0 +1,48 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import uk.gov.hmrc.play.views.html._
+@import controllers.company.routes._
+@import models.Mode
+
+@(appConfig: FrontendAppConfig, form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = messages("companyUniqueTaxReference.title"),
+    appConfig = appConfig,
+    bodyClasses = None) {
+
+    @helpers.form(action = controllers.company.routes.CompanyUniqueTaxReferenceController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("companyUniqueTaxReference.heading", "heading-xlarge", Some("site.secondaryHeader"))
+
+        <p>@messages("companyUniqueTaxReference.body")</p>
+
+        @components.input_text(
+          field = form("value"),
+          label = messages("companyUniqueTaxReference.heading"),
+          hint = Some(messages("companyUniqueTaxReference.hint")),
+          labelClass=Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/register/company/companyRegistrationNumber.scala.html
+++ b/app/views/register/company/companyRegistrationNumber.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import uk.gov.hmrc.play.views.html._
+@import controllers.register.company.routes._
+@import models.Mode
+
+@(appConfig: FrontendAppConfig, form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = messages("companyRegistrationNumber.title"),
+    appConfig = appConfig,
+    bodyClasses = None) {
+
+    @helpers.form(action = controllers.register.company.routes.CompanyRegistrationNumberController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("companyRegistrationNumber.heading", secondaryHeaderKey = Some("site.secondaryHeader"))
+
+        @components.input_text(
+          field = form("value"),
+          label = messages("companyRegistrationNumber.heading"),
+          labelClass=Some("visually-hidden"),
+          hint = Some(messages("companyRegistrationNumber.hint"))
+        )
+
+        @components.submit_button()
+    }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -128,5 +128,5 @@ mongodb {
 
 urls {
   login = "http://localhost:9949/auth-login-stub/gg-sign-in"
-  loginContinue = "http://localhost:9000/pension-administrator-frontend"
+  loginContinue = "http://localhost:9000/pension-administrator"
 }

--- a/conf/company.routes
+++ b/conf/company.routes
@@ -1,0 +1,10 @@
+
+GET        /companyUniqueTaxReference               controllers.company.CompanyUniqueTaxReferenceController.onPageLoad(mode: Mode = NormalMode)
+POST       /companyUniqueTaxReference               controllers.company.CompanyUniqueTaxReferenceController.onSubmit(mode: Mode = NormalMode)
+GET        /changeCompanyUniqueTaxReference                        controllers.company.CompanyUniqueTaxReferenceController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeCompanyUniqueTaxReference                        controllers.company.CompanyUniqueTaxReferenceController.onSubmit(mode: Mode = CheckMode)
+
+GET        /companyRegistrationNumber               controllers.register.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode = NormalMode)
+POST       /companyRegistrationNumber               controllers.register.company.CompanyRegistrationNumberController.onSubmit(mode: Mode = NormalMode)
+GET        /changeCompanyRegistrationNumber                        controllers.register.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeCompanyRegistrationNumber                        controllers.register.company.CompanyRegistrationNumberController.onSubmit(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -39,6 +39,22 @@ site.yes = Yes
 site.save_and_continue = Save and continue
 site.service_name = pension-administrator-frontend
 site.textarea.char_limit = (Limit is {0} characters)
+site.secondaryHeader = Register a new Pension Scheme Administrator
 
 unauthorised.title = You can’t access this service with this account
 unauthorised.heading = You can’t access this service with this account
+
+companyUniqueTaxReference.title = Corporation Tax Unique Taxpayer Reference number
+companyUniqueTaxReference.heading = Corporation Tax Unique Taxpayer Reference number
+companyUniqueTaxReference.body = A CTUTR is issued by HMRC when you register your business.
+companyUniqueTaxReference.hint = A UTR is 10 or 13 digits, if it is 13 digits only enter the last 10.
+companyUniqueTaxReference.checkYourAnswersLabel = companyUniqueTaxReference
+companyUniqueTaxReference.error__required = Please give an answer for companyUniqueTaxReference
+
+companyRegistrationNumber.title = Company Registration number
+companyRegistrationNumber.heading = Company Registration number
+companyRegistrationNumber.checkYourAnswersLabel = Company Registration number
+companyRegistrationNumber.error.required = Enter the Company Registration number
+companyRegistrationNumber.hint = This is issued by Companies House. It is 7 or 8 characters, typically 7 numbers or a combination of 2 letters followed by 6 digits, for example AB123456.
+companyRegistrationNumber.error.length = The Company Registration number cannot be more than 8 characters
+companyRegistrationNumber.error.invalid = Enter a valid 7 or 8 character Company Registration number

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,5 @@
 # Add all the application routes to the app.routes file
-->         /pension-administrator-frontend                    app.Routes
+->         /pension-administrator                    app.Routes
 ->         /                          health.Routes
 ->     	   /template                  template.Routes
 

--- a/migrations/applied_migrations/CompanyRegistrationNumber.sh
+++ b/migrations/applied_migrations/CompanyRegistrationNumber.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+echo "Applying migration CompanyRegistrationNumber"
+
+echo "Adding routes to register.company.routes"
+
+echo "" >> ../conf/register.company.routes
+echo "GET        /companyRegistrationNumber               controllers.register.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/register.company.routes
+echo "POST       /companyRegistrationNumber               controllers.register.company.CompanyRegistrationNumberController.onSubmit(mode: Mode = NormalMode)" >> ../conf/register.company.routes
+
+echo "GET        /changeCompanyRegistrationNumber                        controllers.register.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/register.company.routes
+echo "POST       /changeCompanyRegistrationNumber                        controllers.register.company.CompanyRegistrationNumberController.onSubmit(mode: Mode = CheckMode)" >> ../conf/register.company.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "companyRegistrationNumber.title = companyRegistrationNumber" >> ../conf/messages.en
+echo "companyRegistrationNumber.heading = companyRegistrationNumber" >> ../conf/messages.en
+echo "companyRegistrationNumber.checkYourAnswersLabel = companyRegistrationNumber" >> ../conf/messages.en
+echo "companyRegistrationNumber.error__required = Please give an answer for companyRegistrationNumber" >> ../conf/messages.en
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def companyRegistrationNumber: Option[AnswerRow] = userAnswers.get(identifiers.register.company.CompanyRegistrationNumberId) map {";\
+     print "    x => AnswerRow(\"companyRegistrationNumber.checkYourAnswersLabel\", s\"$x\", false, controllers.register.company.routes.CompanyRegistrationNumberController.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Moving test files from generated-test/ to test/"
+rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
+rm -rf ../generated-test/
+
+echo "Migration CompanyRegistrationNumber completed"

--- a/migrations/applied_migrations/CompanyUniqueTaxReference.sh
+++ b/migrations/applied_migrations/CompanyUniqueTaxReference.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+echo "Applying migration CompanyUniqueTaxReference"
+
+echo "Adding routes to company.routes"
+
+echo "" >> ../conf/company.routes
+echo "GET        /companyUniqueTaxReference               controllers.company.CompanyUniqueTaxReferenceController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/company.routes
+echo "POST       /companyUniqueTaxReference               controllers.company.CompanyUniqueTaxReferenceController.onSubmit(mode: Mode = NormalMode)" >> ../conf/company.routes
+
+echo "GET        /changeCompanyUniqueTaxReference                        controllers.company.CompanyUniqueTaxReferenceController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/company.routes
+echo "POST       /changeCompanyUniqueTaxReference                        controllers.company.CompanyUniqueTaxReferenceController.onSubmit(mode: Mode = CheckMode)" >> ../conf/company.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "companyUniqueTaxReference.title = companyUniqueTaxReference" >> ../conf/messages.en
+echo "companyUniqueTaxReference.heading = companyUniqueTaxReference" >> ../conf/messages.en
+echo "companyUniqueTaxReference.checkYourAnswersLabel = companyUniqueTaxReference" >> ../conf/messages.en
+echo "companyUniqueTaxReference.error__required = Please give an answer for companyUniqueTaxReference" >> ../conf/messages.en
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def companyUniqueTaxReference: Option[AnswerRow] = userAnswers.get(identifiers.company.CompanyUniqueTaxReferenceId) map {";\
+     print "    x => AnswerRow(\"companyUniqueTaxReference.checkYourAnswersLabel\", s\"$x\", false, controllers.company.routes.CompanyUniqueTaxReferenceController.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Moving test files from generated-test/ to test/"
+rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
+rm -rf ../generated-test/
+
+echo "Migration CompanyUniqueTaxReference completed"

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -29,6 +29,7 @@ private object AppDependencies {
   private val playLanguageVersion = "3.4.0"
   private val bootstrapVersion = "1.3.0"
   private val scalacheckVersion = "1.13.4"
+  private val scalacheckGenRegexp = "0.1.0"
 
   val compile = Seq(
     ws,
@@ -58,7 +59,8 @@ private object AppDependencies {
         "org.jsoup" % "jsoup" % "1.10.3" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "org.mockito" % "mockito-all" % mockitoAllVersion % scope,
-        "org.scalacheck" %% "scalacheck" % scalacheckVersion % scope
+        "org.scalacheck" %% "scalacheck" % scalacheckVersion % scope,
+        "wolfendale" %% "scalacheck-gen-regexp" % scalacheckGenRegexp % scope
       )
     }.test
   }

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -60,7 +60,8 @@ trait MicroService {
       .settings(resolvers ++= Seq(
         Resolver.bintrayRepo("hmrc", "releases"),
         Resolver.jcenterRepo,
-        Resolver.bintrayRepo("emueller", "maven")
+        Resolver.bintrayRepo("emueller", "maven"),
+        Resolver.bintrayRepo("wolfendale", "maven")
       ))
     .settings(
       // concatenate js

--- a/test/controllers/company/CompanyUniqueTaxReferenceControllerSpec.scala
+++ b/test/controllers/company/CompanyUniqueTaxReferenceControllerSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.company
+
+import play.api.data.Form
+import play.api.libs.json.JsString
+import uk.gov.hmrc.http.cache.client.CacheMap
+import utils.FakeNavigator
+import connectors.FakeDataCacheConnector
+import controllers.actions._
+import play.api.test.Helpers._
+import forms.company.CompanyUniqueTaxReferenceFormProvider
+import identifiers.company.CompanyUniqueTaxReferenceId
+import models.NormalMode
+import views.html.company.companyUniqueTaxReference
+import play.api.libs.json._
+import controllers.ControllerSpecBase
+
+class CompanyUniqueTaxReferenceControllerSpec extends ControllerSpecBase {
+
+  def onwardRoute = controllers.routes.IndexController.onPageLoad()
+
+  val formProvider = new CompanyUniqueTaxReferenceFormProvider()
+  val form = formProvider()
+
+  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyData) =
+    new CompanyUniqueTaxReferenceController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction,
+      dataRetrievalAction, new DataRequiredActionImpl, formProvider)
+
+  def viewAsString(form: Form[_] = form) = companyUniqueTaxReference(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+
+  val testAnswer = "answer"
+
+  "CompanyUniqueTaxReference Controller" must {
+
+    "return OK and the correct view for a GET" in {
+      val result = controller().onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe OK
+      contentAsString(result) mustBe viewAsString()
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+      val validData = Json.obj(CompanyUniqueTaxReferenceId.toString -> JsString(testAnswer))
+      val getRelevantData = new FakeDataRetrievalAction(Some(validData))
+
+      val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
+
+      contentAsString(result) mustBe viewAsString(form.fill(testAnswer))
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", testAnswer))
+
+      val result = controller().onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(onwardRoute.url)
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", ""))
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val result = controller().onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe BAD_REQUEST
+      contentAsString(result) mustBe viewAsString(boundForm)
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+      val result = controller(dontGetAnyData).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", testAnswer))
+      val result = controller(dontGetAnyData).onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
+    }
+  }
+}

--- a/test/controllers/register/company/CompanyRegistrationNumberControllerSpec.scala
+++ b/test/controllers/register/company/CompanyRegistrationNumberControllerSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.register.company
+
+import play.api.data.Form
+import play.api.libs.json.JsString
+import uk.gov.hmrc.http.cache.client.CacheMap
+import utils.FakeNavigator
+import connectors.FakeDataCacheConnector
+import controllers.actions._
+import play.api.test.Helpers._
+import forms.register.company.CompanyRegistrationNumberFormProvider
+import identifiers.register.company.CompanyRegistrationNumberId
+import models.NormalMode
+import views.html.register.company.companyRegistrationNumber
+import play.api.libs.json._
+import controllers.ControllerSpecBase
+
+class CompanyRegistrationNumberControllerSpec extends ControllerSpecBase {
+
+  def onwardRoute = controllers.routes.IndexController.onPageLoad()
+
+  val formProvider = new CompanyRegistrationNumberFormProvider()
+  val form = formProvider()
+
+  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyData) =
+    new CompanyRegistrationNumberController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction,
+      dataRetrievalAction, new DataRequiredActionImpl, formProvider)
+
+  def viewAsString(form: Form[_] = form) = companyRegistrationNumber(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+
+  val testAnswer = "AB123456"
+
+  "CompanyRegistrationNumber Controller" must {
+
+    "return OK and the correct view for a GET" in {
+      val result = controller().onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe OK
+      contentAsString(result) mustBe viewAsString()
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+      val validData = Json.obj(CompanyRegistrationNumberId.toString -> JsString(testAnswer))
+      val getRelevantData = new FakeDataRetrievalAction(Some(validData))
+
+      val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
+
+      contentAsString(result) mustBe viewAsString(form.fill(testAnswer))
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", testAnswer))
+
+      val result = controller().onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(onwardRoute.url)
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", ""))
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val result = controller().onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe BAD_REQUEST
+      contentAsString(result) mustBe viewAsString(boundForm)
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+      val result = controller(dontGetAnyData).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", testAnswer))
+      val result = controller(dontGetAnyData).onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
+    }
+  }
+}

--- a/test/forms/behaviours/FieldBehaviours.scala
+++ b/test/forms/behaviours/FieldBehaviours.scala
@@ -33,7 +33,7 @@ trait FieldBehaviours extends FormSpec with PropertyChecks with Generators {
       forAll(validDataGenerator -> "validDataItem") {
         dataItem: String =>
           val result = form.bind(Map(fieldName -> dataItem)).apply(fieldName)
-          result.value.value shouldBe dataItem
+          result.errors shouldBe empty
       }
     }
   }

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -34,4 +34,18 @@ trait StringFieldBehaviours extends FieldBehaviours {
       }
     }
   }
+
+  def fieldWithRegex(form: Form[_],
+                     fieldName: String,
+                     invalidString: String,
+                     error: FormError): Unit = {
+
+    "not bind strings invalidated by regex" in {
+      val result = form.bind(Map(fieldName -> invalidString)).apply(fieldName)
+      result.errors shouldEqual Seq(error)
+    }
+
+
+
+  }
 }

--- a/test/forms/company/CompanyUniqueTaxReferenceFormProviderSpec.scala
+++ b/test/forms/company/CompanyUniqueTaxReferenceFormProviderSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.company
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class CompanyUniqueTaxReferenceFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "companyUniqueTaxReference.error.required"
+  val lengthKey = "companyUniqueTaxReference.error.length"
+  val maxLength = 10
+
+  val form = new CompanyUniqueTaxReferenceFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/mappings/ConstraintsSpec.scala
+++ b/test/forms/mappings/ConstraintsSpec.scala
@@ -131,12 +131,9 @@ class ConstraintsSpec extends WordSpec with MustMatchers with Constraints with R
       "ABC123456"
     )
 
-    "Company Registration Number" must {
+    val invalidMsg = "companyRegistrationNumber.error.invalid"
 
-      val invalidMsg = "companyRegistrationNumber.error.invalid"
-
-      behave like regexWithValidAndInvalidExamples(companyRegistrationNumber, validCrn, invalidCrn, invalidMsg, crn)
-    }
+    behave like regexWithValidAndInvalidExamples(companyRegistrationNumber, validCrn, invalidCrn, invalidMsg, crn)
 
   }
 }

--- a/test/forms/mappings/ConstraintsSpec.scala
+++ b/test/forms/mappings/ConstraintsSpec.scala
@@ -19,8 +19,7 @@ package forms.mappings
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.data.validation.{Invalid, Valid}
 
-class ConstraintsSpec extends WordSpec with MustMatchers with Constraints {
-
+class ConstraintsSpec extends WordSpec with MustMatchers with Constraints with RegexBehaviour{
 
   "firstError" must {
 
@@ -115,5 +114,29 @@ class ConstraintsSpec extends WordSpec with MustMatchers with Constraints {
       val result = maxLength(10, "error.length")("a" * 11)
       result mustEqual Invalid("error.length", 10)
     }
+  }
+
+  "companyRegistrationNumber" must {
+
+    val validCrn = Table(
+      "1234567",
+      "A123456",
+      "AB123456"
+    )
+
+    val invalidCrn = Table(
+      "value",
+      "123456",
+      "12345678",
+      "ABC123456"
+    )
+
+    "Company Registration Number" must {
+
+      val invalidMsg = "companyRegistrationNumber.error.invalid"
+
+      behave like regexWithValidAndInvalidExamples(companyRegistrationNumber, validCrn, invalidCrn, invalidMsg, crn)
+    }
+
   }
 }

--- a/test/forms/mappings/RegexBehaviour.scala
+++ b/test/forms/mappings/RegexBehaviour.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.mappings
+
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1}
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.data.validation.{Constraint, Invalid, Valid}
+
+trait RegexBehaviour extends TableDrivenPropertyChecks {
+
+  this: WordSpec with MustMatchers =>
+
+  def regexWithValidAndInvalidExamples(
+                                        constraint: String => Constraint[String],
+                                        valid: TableFor1[String], invalid: TableFor1[String],
+                                        invalidMsg: String,
+                                        regexString: String): Unit = {
+    "Accept all valid examples" in {
+      forAll(valid) {value: String =>
+        constraint(invalidMsg)(value) mustBe Valid
+      }
+    }
+
+    "Rejext all invalid examples" in {
+      forAll(invalid) {value: String =>
+        constraint(invalidMsg)(value) mustBe Invalid(invalidMsg, regexString)
+      }
+    }
+  }
+
+}

--- a/test/forms/mappings/RegexBehaviour.scala
+++ b/test/forms/mappings/RegexBehaviour.scala
@@ -35,7 +35,7 @@ trait RegexBehaviour extends TableDrivenPropertyChecks {
       }
     }
 
-    "Rejext all invalid examples" in {
+    "Reject all invalid examples" in {
       forAll(invalid) {value: String =>
         constraint(invalidMsg)(value) mustBe Invalid(invalidMsg, regexString)
       }

--- a/test/forms/register/company/CompanyRegistrationNumberFormProviderSpec.scala
+++ b/test/forms/register/company/CompanyRegistrationNumberFormProviderSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.register.company
+
+import forms.behaviours.StringFieldBehaviours
+import forms.mappings.Constraints
+import play.api.data.{Form, FormError}
+import wolfendale.scalacheck.regexp.RegexpGen
+
+class CompanyRegistrationNumberFormProviderSpec extends StringFieldBehaviours with Constraints {
+
+  val requiredKey = "companyRegistrationNumber.error.required"
+  val lengthKey = "companyRegistrationNumber.error.length"
+  val invalid = "companyRegistrationNumber.error.invalid"
+  val maxLength = 8
+
+  val form: Form[String] = new CompanyRegistrationNumberFormProvider().apply()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      RegexpGen.from(crn)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithRegex(
+      form,
+      fieldName,
+      "ABC",
+      FormError(fieldName, invalid, Seq(crn))
+    )
+
+
+  }
+}

--- a/test/views/ViewSpecBase.scala
+++ b/test/views/ViewSpecBase.scala
@@ -68,11 +68,11 @@ trait ViewSpecBase extends SpecBase {
   def assertContainsLabel(doc: Document, forElement: String, expectedText: String, expectedHintText: Option[String] = None) = {
     val labels = doc.getElementsByAttributeValue("for", forElement)
     assert(labels.size == 1, s"\n\nLabel for $forElement was not rendered on the page.")
-    val label = labels.first
-    assert(label.text() == expectedText, s"\n\nLabel for $forElement was not $expectedText")
+    val label = labels.select("span")
+    assert(label.first.text() == expectedText, s"\n\nLabel for $forElement was not $expectedText")
 
     if (expectedHintText.isDefined) {
-      assert(label.getElementsByClass("form-hint").first.text == expectedHintText.get,
+      assert(labels.first.getElementsByClass("form-hint").first.text == expectedHintText.get,
         s"\n\nLabel for $forElement did not contain hint text $expectedHintText")
     }
   }

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -16,6 +16,7 @@
 
 package views.behaviours
 
+import org.jsoup.Jsoup
 import play.twirl.api.HtmlFormat
 import views.ViewSpecBase
 
@@ -65,5 +66,14 @@ trait ViewBehaviours extends ViewSpecBase {
         assertRenderedById(doc, "back-link")
       }
     }
+  }
+
+  def pageWithSecondaryHeader(view: () => HtmlFormat.Appendable,
+                              heading: String) = {
+
+    "behave like a page with a secondary header" in {
+      Jsoup.parse(view().toString()).getElementsByClass("heading-secondary").text() must include(heading)
+    }
+
   }
 }

--- a/test/views/company/CompanyUniqueTaxReferenceViewSpec.scala
+++ b/test/views/company/CompanyUniqueTaxReferenceViewSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.company
+
+import play.api.data.Form
+import controllers.company.routes
+import forms.company.CompanyUniqueTaxReferenceFormProvider
+import models.NormalMode
+import views.behaviours.StringViewBehaviours
+import views.html.company.companyUniqueTaxReference
+
+class CompanyUniqueTaxReferenceViewSpec extends StringViewBehaviours {
+
+  val messageKeyPrefix = "companyUniqueTaxReference"
+  val expectedHintKey = "companyUniqueTaxReference.hint"
+  val expectedBodyText = "companyUniqueTaxReference.body"
+
+  val form = new CompanyUniqueTaxReferenceFormProvider()()
+
+  def createView = () => companyUniqueTaxReference(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+
+  def createViewUsingForm = (form: Form[String]) => companyUniqueTaxReference(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+
+  "CompanyUniqueTaxReference view" must {
+    behave like normalPage(createView, messageKeyPrefix)
+
+    behave like pageWithBackLink(createView)
+
+    behave like stringPage(createViewUsingForm, messageKeyPrefix,
+      controllers.company.routes.CompanyUniqueTaxReferenceController.onSubmit(NormalMode).url, Some(expectedHintKey) )
+
+    "display correct body text" in {
+
+      val doc = asDocument(createView())
+      assertContainsText(doc, messages(expectedBodyText))
+
+    }
+  }
+}

--- a/test/views/register/company/CompanyRegistrationNumberViewSpec.scala
+++ b/test/views/register/company/CompanyRegistrationNumberViewSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.register.company
+
+import play.api.data.Form
+import controllers.register.company.routes
+import forms.register.company.CompanyRegistrationNumberFormProvider
+import models.NormalMode
+import views.behaviours.StringViewBehaviours
+import views.html.register.company.companyRegistrationNumber
+
+class CompanyRegistrationNumberViewSpec extends StringViewBehaviours {
+
+  val messageKeyPrefix = "companyRegistrationNumber"
+
+  val form = new CompanyRegistrationNumberFormProvider()()
+
+  def createView = () => companyRegistrationNumber(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+
+  def createViewUsingForm = (form: Form[String]) => companyRegistrationNumber(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+
+  "CompanyRegistrationNumber view" must {
+    behave like normalPage(createView, messageKeyPrefix)
+
+    behave like pageWithBackLink(createView)
+
+    behave like pageWithSecondaryHeader(createView, messages("site.secondaryHeader"))
+
+    behave like stringPage(
+      createViewUsingForm,
+      messageKeyPrefix,
+      controllers.register.company.routes.CompanyRegistrationNumberController.onSubmit(NormalMode).url,
+      Some(s"$messageKeyPrefix.hint")
+    )
+  }
+}


### PR DESCRIPTION
Update ViewSpecBase label test to accomodate hint text in label, add messages for companyRegNo

Add to messages companyRegistrationNumber.error.length

PODS-463 - Adding CTUTR page

Porting styles over from PODS reg

remove register.company.routes, add secondaryHeader to crn view

Add companyRegNumber validation regex to conf

Utilise RegexBehaviour for companyRegistrationNumber constraint

Implmement rn constraint to CompanyRegistrationNumberFormProvider

Update CompanyRegistrationNumberControllerSpec for valid input

Implement RegexpGen courtesy of wolfendale.scalacheck.regexp