### PR TITLE
PODS-464: Company address

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -46,12 +46,17 @@ class FrontendAppConfig @Inject() (override val runModeConfiguration: Configurat
   lazy val loginContinueUrl: String = loadConfig("urls.loginContinue")
 
   lazy val languageTranslationEnabled: Boolean = runModeConfiguration.getBoolean("microservice.services.features.welsh-translation").getOrElse(true)
-  lazy val locationCanonicalList = loadConfig("location.canonical.list")
+  lazy val locationCanonicalList: String = loadConfig("location.canonical.list")
   lazy val maxDirectors: Int = loadConfig("register.company.maxDirectors").toInt
 
   def languageMap: Map[String, Lang] = Map(
     "english" -> Lang("en"),
     "cymraeg" -> Lang("cy"))
   def routeToSwitchLanguage: String => Call = (lang: String) => routes.LanguageSwitchController.switchToLanguage(lang)
+
   lazy val addressLookUp: String = baseUrl("address-lookup")
+
+  lazy val registerWithIdOrganisationUrl: String =
+      baseUrl("pensions-scheme") +
+      runModeConfiguration.underlying.getString("urls.pension-scheme.registerWithIdOrganisation")
 }

--- a/app/connectors/RegistrationConnector.scala
+++ b/app/connectors/RegistrationConnector.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import javax.inject.Singleton
+
+import com.google.inject.{ImplementedBy, Inject}
+import config.FrontendAppConfig
+import models.{Organisation, RegisterWithIdResponse}
+import play.api.Logger
+import play.api.http.Status
+import play.api.libs.json.{JsError, JsResultException, JsSuccess, Json}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Failure
+
+@ImplementedBy(classOf[RegistrationConnectorImpl])
+trait RegistrationConnector {
+  def registerWithIdOrganisation
+      (utr: String, organisation: Organisation)
+      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[RegisterWithIdResponse]
+}
+
+@Singleton
+class RegistrationConnectorImpl @Inject()(http: HttpClient, config: FrontendAppConfig) extends RegistrationConnector {
+
+  override def registerWithIdOrganisation
+      (utr: String, organisation: Organisation)
+      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[RegisterWithIdResponse] = {
+
+    val url = config.registerWithIdOrganisationUrl
+
+    val body = Json.obj(
+      "utr" -> utr,
+      "organisationName" -> organisation.organisationName,
+      "organisationType" -> organisation.organisationType.toString
+    )
+
+    http.POST(url, body) map {response =>
+      require(response.status == Status.OK, "The only valid response to registerWithIdOrganisation is 200 OK")
+      Json.parse(response.body).validate[RegisterWithIdResponse] match {
+        case JsSuccess(value, _) => value
+        case JsError(errors) => throw JsResultException(errors)
+      }
+    } andThen {
+      case Failure(ex) =>
+        Logger.error("Unable to connect to RegisterWithId", ex)
+        ex
+    }
+  }
+
+}

--- a/app/controllers/register/company/CompanyAddressController.scala
+++ b/app/controllers/register/company/CompanyAddressController.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.register.company
+
+import javax.inject.Inject
+
+import play.api.i18n.{I18nSupport, MessagesApi}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import controllers.actions._
+import config.FrontendAppConfig
+import connectors.{DataCacheConnector, RegistrationConnector}
+import controllers.Retrievals
+import identifiers.register.company.{CompanyAddressId, CompanyDetailsId, CompanyUniqueTaxReferenceId}
+import models.{Mode, Organisation, OrganisationTypeEnum}
+import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.http.NotFoundException
+import utils.Navigator
+import views.html.register.company.companyAddress
+
+class CompanyAddressController @Inject()(appConfig: FrontendAppConfig,
+                                         override val messagesApi: MessagesApi,
+                                         dataCacheConnector: DataCacheConnector,
+                                         navigator: Navigator,
+                                         authenticate: AuthAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         registrationConnector: RegistrationConnector
+                                        ) extends FrontendController with I18nSupport with Retrievals {
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (authenticate andThen getData andThen requireData).async {
+    implicit request =>
+      retrieve(CompanyDetailsId)( companyDetails => {
+        retrieve(CompanyUniqueTaxReferenceId)( utr => {
+          val organisation = Organisation(companyDetails.companyName, OrganisationTypeEnum.CorporateBody)
+
+          registrationConnector.registerWithIdOrganisation(utr, organisation).flatMap { response =>
+            dataCacheConnector.save(request.externalId, CompanyAddressId, response.address).map(_ =>
+              Ok(companyAddress(appConfig, response.address)))
+          } recover {
+            case _: NotFoundException =>
+              Redirect(navigator.nextPage(CompanyDetailsId, mode)(request.userAnswers))
+          }
+        })
+      })
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (authenticate andThen getData andThen requireData) {
+    implicit request =>
+      Redirect(navigator.nextPage(CompanyDetailsId, mode)(request.userAnswers))
+  }
+
+}

--- a/app/identifiers/register/company/CompanyAddressId.scala
+++ b/app/identifiers/register/company/CompanyAddressId.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package identifiers.register.company
+
+import identifiers.TypedIdentifier
+import models.TolerantAddress
+
+case object CompanyAddressId extends TypedIdentifier[TolerantAddress] {
+  override def toString = "companyAddressId"
+}

--- a/app/models/Organisation.scala
+++ b/app/models/Organisation.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.Json
+import play.api.libs.json._
+import utils.EnumUtils
+
+object OrganisationTypeEnum extends Enumeration {
+  type OrganisationType = Value
+  val CorporateBody = Value("Corporate Body")
+  val NotSpecified = Value("Not Specified")
+  val LLP = Value("LLP")
+  val Partnership = Value("Partnership")
+  val UnincorporatedBody = Value("Unincorporated Body")
+
+  implicit def enumFormats: Format[OrganisationType] = EnumUtils.enumFormat(OrganisationTypeEnum)
+}
+
+case class Organisation(organisationName: String, organisationType: OrganisationTypeEnum.OrganisationType)
+
+object Organisation {
+  implicit val formats = Json.format[Organisation]
+}

--- a/app/models/RegisterWithIdResponse.scala
+++ b/app/models/RegisterWithIdResponse.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json._
+
+case class RegisterWithIdResponse(address: TolerantAddress)
+
+object RegisterWithIdResponse {
+
+  implicit lazy val readsRegisterWithIdResponse: Reads[RegisterWithIdResponse] =
+    (JsPath \ "address").read[TolerantAddress].map { address =>
+      RegisterWithIdResponse(address)
+    }
+
+  implicit lazy val writesRegisterWithIdResponse: Writes[RegisterWithIdResponse] = Writes[RegisterWithIdResponse] { response =>
+    Json.obj(
+      "address" -> response.address
+    )
+  }
+
+}

--- a/app/models/TolerantAddress.scala
+++ b/app/models/TolerantAddress.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Format, JsPath}
+
+case class TolerantAddress(addressLine1: Option[String],
+                           addressLine2: Option[String],
+                           addressLine3: Option[String],
+                           addressLine4: Option[String],
+                           postcode: Option[String],
+                           country: Option[String])
+
+object TolerantAddress {
+
+  implicit lazy val formatsTolerantAddress: Format[TolerantAddress] = (
+    (JsPath \ "addressLine1").formatNullable[String] and
+    (JsPath \ "addressLine2").formatNullable[String] and
+    (JsPath \ "addressLine3").formatNullable[String] and
+    (JsPath \ "addressLine4").formatNullable[String] and
+    (JsPath \ "postalCode").formatNullable[String] and
+    (JsPath \ "countryCode").formatNullable[String]
+  )(TolerantAddress.apply, unlift(TolerantAddress.unapply))
+
+}

--- a/app/utils/EnumUtils.scala
+++ b/app/utils/EnumUtils.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import play.api.libs.json._
+import scala.language.implicitConversions
+
+object EnumUtils {
+  def enumReads[E <: Enumeration](enum: E): Reads[E#Value] = new Reads[E#Value] {
+    def reads(json: JsValue): JsResult[E#Value] = json match {
+      case JsString(s) => {
+        try {
+          JsSuccess(enum.withName(s))
+        } catch {
+          case _: NoSuchElementException => JsError(s"Enumeration expected of type: '${enum.getClass}'," +
+            s"but it does not appear to contain the value: '$s'")
+        }
+      }
+      case _ => JsError("String value expected")
+    }
+  }
+
+  implicit def enumWrites[E <: Enumeration]: Writes[E#Value] = new Writes[E#Value] {
+    def writes(v: E#Value): JsValue = JsString(v.toString)
+  }
+
+  implicit def enumFormat[E <: Enumeration](enum: E): Format[E#Value] = {
+    Format(enumReads(enum), enumWrites)
+  }
+}

--- a/app/views/components/tolerant_address.scala.html
+++ b/app/views/components/tolerant_address.scala.html
@@ -1,0 +1,40 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import models.TolerantAddress
+
+@(fieldName: String, address: TolerantAddress)
+
+<p>
+    @if(address.addressLine1.isDefined) {
+        <div id="@fieldName-addressLine1">@address.addressLine1,</div>
+    }
+    @if(address.addressLine2.isDefined) {
+        <div id="@fieldName-addressLine2">@address.addressLine2,</div>
+    }
+    @if(address.addressLine3.isDefined) {
+        <div id="@fieldName-addressLine3">@address.addressLine3,</div>
+    }
+    @if(address.addressLine4.isDefined) {
+        <div id="@fieldName-addressLine4">@address.addressLine4,</div>
+    }
+    @if(address.postcode.isDefined) {
+        <div id="@fieldName-postcode">@address.postcode,</div>
+    }
+    @if(address.country.isDefined) {
+        <div id="@fieldName-country">@address.country</div>
+    }
+</p>

--- a/app/views/register/company/companyAddress.scala.html
+++ b/app/views/register/company/companyAddress.scala.html
@@ -1,0 +1,38 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import controllers.register.company.routes._
+@import models.TolerantAddress
+@import uk.gov.hmrc.play.views.html._
+
+@(appConfig: FrontendAppConfig, address: TolerantAddress)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = messages("companyAddress.title"),
+    appConfig = appConfig,
+    bodyClasses = None) {
+
+    @helpers.form(action = CompanyAddressController.onSubmit(), 'autoComplete -> "off") {
+        @components.back_link()
+
+        @components.heading("companyAddress.heading", secondaryHeaderKey = Some("site.secondaryHeader"))
+
+        @components.tolerant_address("companyAddress", address)
+
+        @components.submit_button()
+    }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,6 +92,11 @@ microservice {
         host = localhost
         port = 9022
       }
+
+      pensions-scheme {
+        host = localhost
+        port = 8203
+      }
     }
 }
 
@@ -138,4 +143,7 @@ mongodb {
 urls {
   login = "http://localhost:9949/auth-login-stub/gg-sign-in"
   loginContinue = "http://localhost:9000/pension-administrator"
+  pension-scheme {
+    registerWithIdOrganisation = "/pensions-scheme/register-with-id/organisation"
+  }
 }

--- a/conf/company.routes
+++ b/conf/company.routes
@@ -102,3 +102,6 @@ GET        /directors/:index/directorContactDetails                       contro
 POST       /directors/:index/directorContactDetails                       controllers.register.company.DirectorContactDetailsController.onSubmit(mode: Mode = NormalMode, index: Index)
 GET        /directors/:index/changeDirectorContactDetails                       controllers.register.company.DirectorContactDetailsController.onPageLoad(mode: Mode = CheckMode, index: Index)
 POST       /directors/:index/changeDirectorContactDetails                       controllers.register.company.DirectorContactDetailsController.onSubmit(mode: Mode = CheckMode, index: Index)
+
+GET        /companyAddress                       controllers.register.company.CompanyAddressController.onPageLoad(mode: Mode = NormalMode)
+POST       /companyAddress                       controllers.register.company.CompanyAddressController.onSubmit(mode: Mode = NormalMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -247,3 +247,6 @@ directorAddress.heading = Director’s address
 directorContactDetails.title = Contact details for director
 directorContactDetails.heading = Contact details for director
 directorContactDetails.checkYourAnswersLabel = Contact details for director
+
+companyAddress.title = Company address
+companyAddress.heading = Company address

--- a/migrations/applied_migrations/CompanyAddress.sh
+++ b/migrations/applied_migrations/CompanyAddress.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Applying migration CompanyAddress"
+
+echo "Adding routes to register.company.routes"
+echo "" >> ../conf/register.company.routes
+echo "GET        /companyAddress                       controllers.register.company.CompanyAddressController.onPageLoad()" >> ../conf/register.company.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "companyAddress.title = companyAddress" >> ../conf/messages.en
+echo "companyAddress.heading = companyAddress" >> ../conf/messages.en
+
+echo "Moving test files from generated-test/ to test/"
+rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
+rm -rf ../generated-test/
+
+echo "Migration CompanyAddress completed"

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -31,6 +31,7 @@ private object AppDependencies {
   private val scalacheckVersion = "1.13.4"
   private val scalacheckGenRegexp = "0.1.0"
   private val domainVersion = "5.1.0"
+  private val wireMockVersion = "2.15.0"
 
   val compile = Seq(
     ws,
@@ -62,7 +63,8 @@ private object AppDependencies {
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "org.mockito" % "mockito-all" % mockitoAllVersion % scope,
         "org.scalacheck" %% "scalacheck" % scalacheckVersion % scope,
-        "wolfendale" %% "scalacheck-gen-regexp" % scalacheckGenRegexp % scope
+        "wolfendale" %% "scalacheck-gen-regexp" % scalacheckGenRegexp % scope,
+        "com.github.tomakehurst" % "wiremock" % wireMockVersion % scope
       )
     }.test
   }

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -44,7 +44,6 @@ trait MicroService {
     .settings(publishingSettings: _*)
     .settings(defaultSettings(): _*)
     .settings(
-      PlayKeys.devSettings += "play.server.http.port" -> "8201",
       scalacOptions ++= Seq("-Xfatal-warnings", "-feature"),
       libraryDependencies ++= appDependencies,
       retrieveManaged := true,
@@ -83,7 +82,9 @@ trait MicroService {
     .settings(
       PlayKeys.devSettings ++= Seq(
         "metrics.enabled" -> "false",
-        "auditing.enabled" -> "false"
+        "auditing.enabled" -> "false",
+        "play.server.http.port" -> "8201",
+        "urls.loginContinue" -> "http://localhost:8201/pension-administrator"
       )
     )
 }

--- a/test/connectors/RegistrationConnectorSpec.scala
+++ b/test/connectors/RegistrationConnectorSpec.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import models.{TolerantAddress, Organisation, OrganisationTypeEnum}
+import org.scalatest._
+import play.api.http.Status
+import play.api.libs.json.{JsResultException, Json}
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
+import utils.WireMockHelper
+
+class RegistrationConnectorSpec ()
+  extends AsyncFlatSpec with Matchers with OptionValues with WireMockHelper {
+
+  override protected def portConfigKey: String = "microservice.services.pensions-scheme.port"
+
+  private implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+
+  private val utr = "1234567890"
+  private val path = "/pensions-scheme/register-with-id/organisation"
+
+  private val organisation = Organisation("Test Ltd", OrganisationTypeEnum.CorporateBody)
+
+  private val expectedAddress = TolerantAddress(
+    Some("Building Name"),
+    Some("1 Main Street"),
+    Some("Some Village"),
+    Some("Some Town"),
+    Some("GB"),
+    Some("ZZ1 1ZZ")
+  )
+
+  private val validResponse = Json.obj(
+    "safeId" -> "",
+    "isEditable" -> false,
+    "isAnAgent" -> false,
+    "isAnIndividual" -> false,
+    "organisation" -> Json.obj(
+      "organisationName" -> organisation.organisationName,
+      "organisationType" -> organisation.organisationType.toString
+    ),
+    "address" -> Json.obj(
+      "addressLine1" -> expectedAddress.addressLine1.value,
+      "addressLine2" -> expectedAddress.addressLine2.value,
+      "addressLine3" -> expectedAddress.addressLine3.value,
+      "addressLine4" -> expectedAddress.addressLine4.value,
+      "countryCode" -> expectedAddress.country.value,
+      "postalCode" -> expectedAddress.postcode.value
+    ),
+    "contactDetails" -> Json.obj()
+  )
+
+  private val invalidResponse = Json.obj(
+    "invalid-element" -> "Meh!"
+  )
+
+  "CompanyAddressConnector" should "return the address given a valid UTR" in {
+
+    server.stubFor(
+      post(urlEqualTo(path))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+            .withHeader("Content-Type", "application/json")
+            .withBody(Json.stringify(validResponse))
+        )
+    )
+
+    val connector = injector.instanceOf[RegistrationConnectorImpl]
+    connector.registerWithIdOrganisation(utr, organisation).map { response =>
+      response.address shouldBe expectedAddress
+    }
+
+  }
+
+  it should "only accept valid requests with status 200 OK" in {
+
+    server.stubFor(
+      post(urlEqualTo(path))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.ACCEPTED)
+            .withHeader("Content-Type", "application/json")
+            .withBody(Json.stringify(validResponse))
+        )
+    )
+
+    val connector = injector.instanceOf[RegistrationConnectorImpl]
+    recoverToSucceededIf[IllegalArgumentException] {
+      connector.registerWithIdOrganisation(utr, organisation)
+    }
+
+  }
+
+  it should "propagate exceptions from HttpClient" in {
+
+    server.stubFor(
+      post(urlEqualTo(path))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.NOT_FOUND)
+        )
+    )
+
+    val connector = injector.instanceOf[RegistrationConnectorImpl]
+    recoverToSucceededIf[NotFoundException] {
+      connector.registerWithIdOrganisation(utr, organisation)
+    }
+
+  }
+
+  it should "identify JSON parse errors" in {
+
+    server.stubFor(
+      post(urlEqualTo(path))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+            .withHeader("Content-Type", "application/json")
+            .withBody(Json.stringify(invalidResponse))
+        )
+    )
+
+    val connector = injector.instanceOf[RegistrationConnectorImpl]
+    recoverToSucceededIf[JsResultException] {
+      connector.registerWithIdOrganisation(utr, organisation)
+    }
+
+  }
+
+}

--- a/test/controllers/register/company/CompanyAddressControllerSpec.scala
+++ b/test/controllers/register/company/CompanyAddressControllerSpec.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.register.company
+
+import connectors.{FakeDataCacheConnector, RegistrationConnector}
+import controllers.ControllerSpecBase
+import controllers.actions._
+import identifiers.register.company.{CompanyAddressId, CompanyDetailsId, CompanyUniqueTaxReferenceId}
+import models.register.company.CompanyDetails
+import models.{TolerantAddress, NormalMode, Organisation, RegisterWithIdResponse}
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
+import utils.FakeNavigator
+import views.html.register.company.companyAddress
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CompanyAddressControllerSpec extends ControllerSpecBase {
+
+  private def onwardRoute = controllers.routes.IndexController.onPageLoad()
+
+  private val testAddress = TolerantAddress(
+    Some("Some Building"),
+    Some("1 Some Street"),
+    Some("Some Village"),
+    Some("Some Town"),
+    Some("ZZ1 1ZZ"),
+    Some("UK")
+  )
+
+  private val validUtr = "1234567890"
+  private val invalidUtr = "INVALID"
+
+  private def fakeRegistrationConnector = new RegistrationConnector {
+    override def registerWithIdOrganisation
+        (utr: String, organisation: Organisation)
+        (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[RegisterWithIdResponse] = {
+
+        if (utr == validUtr) {
+          Future.successful(RegisterWithIdResponse(testAddress))
+        }
+        else {
+          Future.failed(new NotFoundException(s"Unnown UTR: $utr"))
+        }
+    }
+  }
+
+  private def controller(dataRetrievalAction: DataRetrievalAction = getEmptyData) =
+    new CompanyAddressController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction,
+      dataRetrievalAction, new DataRequiredActionImpl, fakeRegistrationConnector)
+
+  private def viewAsString(): String = companyAddress(frontendAppConfig, testAddress)(fakeRequest, messages).toString
+
+  "CompanyAddress Controller" must {
+
+    "return OK and the correct view for a GET when UTR is valid" in {
+      val data = Json.obj(
+        CompanyDetailsId.toString -> CompanyDetails("MyCo", None, None),
+        CompanyUniqueTaxReferenceId.toString -> validUtr
+      )
+      val dataRetrievalAction = new FakeDataRetrievalAction(Some(data))
+      val result = controller(dataRetrievalAction).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe OK
+      contentAsString(result) mustBe viewAsString()
+    }
+
+    "save the address to user answers when UTR is valid" in {
+      val data = Json.obj(
+        CompanyDetailsId.toString -> CompanyDetails("MyCo", None, None),
+        CompanyUniqueTaxReferenceId.toString -> validUtr
+      )
+      val dataRetrievalAction = new FakeDataRetrievalAction(Some(data))
+      val result = controller(dataRetrievalAction).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe OK
+      FakeDataCacheConnector.verify(CompanyAddressId, testAddress)
+    }
+
+    "redirect to the next page when the UTR is invalid" in {
+      val data = Json.obj(
+        CompanyDetailsId.toString -> CompanyDetails("MyCo", None, None),
+        CompanyUniqueTaxReferenceId.toString -> invalidUtr
+      )
+      val dataRetrievalAction = new FakeDataRetrievalAction(Some(data))
+      val result = controller(dataRetrievalAction).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(onwardRoute.url)
+    }
+
+    "redirect to Session Expired for a GET if no company details data is found" in {
+      val data = Json.obj(
+        CompanyUniqueTaxReferenceId.toString -> invalidUtr
+      )
+
+      val dataRetrievalAction = new FakeDataRetrievalAction(Some(data))
+      val result = controller(dataRetrievalAction).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
+    }
+
+    "redirect to Session Expired for a GET if no UTR data is found" in {
+      val data = Json.obj(
+        CompanyDetailsId.toString -> CompanyDetails("MyCo", None, None)
+      )
+
+      val dataRetrievalAction = new FakeDataRetrievalAction(Some(data))
+      val result = controller(dataRetrievalAction).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
+    }
+
+    "redirect to the next page on a POST" in {
+      val result = controller().onSubmit(NormalMode)(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(onwardRoute.url)
+    }
+
+  }
+
+}

--- a/test/utils/WireMockHelper.scala
+++ b/test/utils/WireMockHelper.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
+import play.api.Application
+import play.api.inject.Injector
+import play.api.inject.guice.GuiceApplicationBuilder
+
+trait WireMockHelper extends BeforeAndAfterAll with BeforeAndAfterEach {
+  this: Suite =>
+
+  protected val server: WireMockServer = new WireMockServer(wireMockConfig().dynamicPort())
+
+  protected def portConfigKey: String
+
+  protected lazy val app: Application =
+    new GuiceApplicationBuilder()
+      .configure(
+        portConfigKey -> server.port().toString,
+        "auditing.enabled" -> false,
+        "metrics.enabled" -> false
+      )
+      .build()
+
+  protected lazy val injector: Injector = app.injector
+
+  override def beforeAll(): Unit = {
+    server.start()
+    super.beforeAll()
+  }
+
+  override def beforeEach(): Unit = {
+    server.resetAll()
+    super.beforeEach()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    server.stop()
+  }
+
+}

--- a/test/views/behaviours/AddressBehaviours.scala
+++ b/test/views/behaviours/AddressBehaviours.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import models.TolerantAddress
+import play.twirl.api.HtmlFormat
+import views.ViewSpecBase
+
+trait AddressBehaviours {
+  this: ViewSpecBase =>
+
+  def pageWithAddress(createView: TolerantAddress => HtmlFormat.Appendable, fieldName: String): Unit = {
+
+    "display an address correctly" when {
+      "rendering a full address" in {
+        val address = TolerantAddress(
+          Some("Some Building"),
+          Some("1 Some Street"),
+          Some("Some Village"),
+          Some("Some Town"),
+          Some("ZZ1 1ZZ"),
+          Some("UK")
+        )
+
+        val doc = asDocument(createView(address))
+        assertRenderedByIdWithText(doc, s"$fieldName-addressLine1", address.addressLine1.value + ",")
+        assertRenderedByIdWithText(doc, s"$fieldName-addressLine2", address.addressLine2.value + ",")
+        assertRenderedByIdWithText(doc, s"$fieldName-addressLine3", address.addressLine3.value + ",")
+        assertRenderedByIdWithText(doc, s"$fieldName-addressLine4", address.addressLine4.value + ",")
+        assertRenderedByIdWithText(doc, s"$fieldName-postcode", address.postcode.value + ",")
+        assertRenderedByIdWithText(doc, s"$fieldName-country", address.country.value)
+      }
+
+      "rendering a minimal address" in {
+        val address = TolerantAddress(
+          Some("Some Building"),
+          Some("1 Some Street"),
+          None,
+          None,
+          None,
+          Some("UK")
+        )
+
+        val doc = asDocument(createView(address))
+        assertRenderedByIdWithText(doc, s"$fieldName-addressLine1", address.addressLine1.value + ",")
+        assertRenderedByIdWithText(doc, s"$fieldName-addressLine2", address.addressLine2.value + ",")
+        assertRenderedByIdWithText(doc, s"$fieldName-country", address.country.value)
+
+        assertNotRenderedById(doc, s"$fieldName-addressLine3")
+        assertNotRenderedById(doc, s"$fieldName-addressLine4")
+        assertNotRenderedById(doc, s"$fieldName-postcode")
+      }
+    }
+
+  }
+
+}

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -76,4 +76,12 @@ trait ViewBehaviours extends ViewSpecBase {
     }
 
   }
+
+  def pageWithSubmitButton(view: () => HtmlFormat.Appendable): Unit = {
+    "behave like a page with a submit button" in {
+      val doc = asDocument(view())
+      assertRenderedById(doc, "submit")
+    }
+  }
+
 }

--- a/test/views/register/company/CompanyAddressViewSpec.scala
+++ b/test/views/register/company/CompanyAddressViewSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.register.company
+
+import models.TolerantAddress
+import views.behaviours.{AddressBehaviours, ViewBehaviours}
+import views.html.register.company.companyAddress
+
+class CompanyAddressViewSpec extends ViewBehaviours with AddressBehaviours {
+
+  private val messageKeyPrefix = "companyAddress"
+
+  private val testAddress = TolerantAddress(
+    Some("Some Building"),
+    Some("1 Some Street"),
+    Some("Some Village"),
+    Some("Some Town"),
+    Some("ZZ1 1ZZ"),
+    Some("UK")
+  )
+
+  private def createView(address: TolerantAddress = testAddress) = () => companyAddress(frontendAppConfig, address)(fakeRequest, messages)
+
+  "CompanyAddress view" must {
+    behave like normalPage(createView(), messageKeyPrefix)
+
+    behave like pageWithBackLink(createView())
+
+    behave like pageWithSecondaryHeader(createView(), messages("site.secondaryHeader") )
+
+    behave like pageWithAddress((address) => createView(address)(), "companyAddress")
+
+    behave like pageWithSubmitButton(createView())
+  }
+
+}


### PR DESCRIPTION
Implemented view

Moved address tests to behaviour

Pass address from controller

Adding company address connector

More connector

More connector work

Fixed test issue

Update messages.en

PODS-482 Reg PSA (UK) - Company - Director -Previous address - postcode lookup

Merge branch 'master' into PODS-482
Fixed test issue

Merge routes

Update message keys for address

Update messages.en
Merge pull request #39 from hmrc/PODS-480

Pods 480
Merge branch 'master' into PODS-482

Scaffold generated

Implemented view

Added connector

Completed connector

Controller tests

Changed CompanyAddress to TolerantAddress

View adjustments to prototype

Compilation failure after rebase