### PR TITLE
Pods 832:  Send nonUK postalCode only if within length params of enrolments

### DIFF
--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -133,6 +133,7 @@ trait Constraints {
       case _ => Invalid(invalidKey)
     }
   }
+
   protected def name(errorKey: String): Constraint[String] = regexp(nameRegex, errorKey)
 
   protected def addressLine(errorKey: String): Constraint[String] = regexp(addressLineRegex, errorKey)

--- a/app/utils/KnownFactsRetrieval.scala
+++ b/app/utils/KnownFactsRetrieval.scala
@@ -45,11 +45,12 @@ class KnownFactsRetrieval {
             country <- address.country
           } yield {
             val knownFacts = Set(KnownFact(countryKey, country))
-            KnownFacts(
-              address.postcode.fold(knownFacts) { postalCode =>
-                knownFacts + KnownFact(postalKey, postalCode)
+            KnownFacts {
+              address.postcode match {
+                case Some(postalCode) if postalCode.length > 0 & postalCode.length < 11 => knownFacts + KnownFact(postalKey, postalCode)
+                case _ => knownFacts
               }
-            )
+            }
           }
         case _ => None
       }

--- a/test/forms/mappings/ConstraintsSpec.scala
+++ b/test/forms/mappings/ConstraintsSpec.scala
@@ -215,7 +215,6 @@ class ConstraintsSpec extends FormSpec with Matchers with Constraints with Regex
     behave like regexWithValidAndInvalidExamples(payeEmployerReferenceNumber, validPaye, invalidPaye, invalidMsg, payeRegex)
   }
 
-
   "email" must {
 
     val validEmail = Table(
@@ -292,7 +291,8 @@ class ConstraintsSpec extends FormSpec with Matchers with Constraints with Regex
       "postCode",
       "1",
       "1234567890",
-      "1-2-3"
+      "1-2-3",
+      "98765434567898765"
     )
 
     val invalidPostCode = Table(


### PR DESCRIPTION
According to Enrolments spec, non-uk postal code can only be between 1 and 10 characters long.
We do not validate length, so do not send if it breaks enrolments' validation.