### PR TITLE
PODS-1157: Adding new navigator to allow user to return to the last page when logging back in

### DIFF
--- a/app/PODSModule.scala
+++ b/app/PODSModule.scala
@@ -15,7 +15,7 @@
  */
 
 import com.google.inject.AbstractModule
-import utils.Navigator
+import utils.{Navigator, Navigator2}
 import utils.annotations._
 import utils.countryOptions.{CountryOptions, CountryOptionsEUAndEEA}
 import utils.navigators._
@@ -27,6 +27,10 @@ class PODSModule extends AbstractModule {
     bind(classOf[Navigator])
       .annotatedWith(classOf[Register])
       .to(classOf[RegisterNavigator])
+
+    bind(classOf[Navigator2])
+      .annotatedWith(classOf[Register])
+      .to(classOf[RegisterNavigator2])
 
     bind(classOf[Navigator])
       .annotatedWith(classOf[CompanyDirector])

--- a/app/controllers/register/DeclarationController.scala
+++ b/app/controllers/register/DeclarationController.scala
@@ -17,7 +17,6 @@
 package controllers.register
 
 import javax.inject.Inject
-
 import com.google.inject.Singleton
 import config.FrontendAppConfig
 import connectors.DataCacheConnector
@@ -30,7 +29,7 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import utils.annotations.Register
-import utils.{Navigator, UserAnswers}
+import utils.{Navigator, Navigator2, UserAnswers}
 import views.html.register.declaration
 
 import scala.concurrent.Future
@@ -41,7 +40,7 @@ class DeclarationController @Inject()(appConfig: FrontendAppConfig,
                                       authenticate: AuthAction,
                                       getData: DataRetrievalAction,
                                       requireData: DataRequiredAction,
-                                      @Register navigator: Navigator,
+                                      @Register navigator: Navigator2,
                                       formProvider: DeclarationFormProvider,
                                       dataCacheConnector: DataCacheConnector) extends FrontendController with I18nSupport {
 
@@ -71,7 +70,7 @@ class DeclarationController @Inject()(appConfig: FrontendAppConfig,
                 declaration(appConfig, errors, company.routes.WhatYouWillNeedController.onPageLoad())))
           },
         success => dataCacheConnector.save(request.externalId, DeclarationId, success).map { cacheMap =>
-          Redirect(navigator.nextPage(DeclarationId, NormalMode)(UserAnswers(cacheMap)))
+          Redirect(navigator.nextPage(DeclarationId, NormalMode, UserAnswers(cacheMap)))
         }
       )
   }

--- a/app/identifiers/LastPageId.scala
+++ b/app/identifiers/LastPageId.scala
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package models.requests
+package identifiers
 
-import models.PSAUser
-import play.api.mvc.{Request, WrappedRequest}
-import utils.UserAnswers
+import models.LastPage
 
-case class OptionalDataRequest[A] (request: Request[A], externalId: String, user: PSAUser,
-                                   userAnswers: Option[UserAnswers]) extends WrappedRequest[A](request) with IdentifiedRequest
-
-case class DataRequest[A] (request: Request[A], externalId: String, user: PSAUser,
-                           userAnswers: UserAnswers) extends WrappedRequest[A](request) with IdentifiedRequest
+object LastPageId extends TypedIdentifier[LastPage] {
+  override def toString: String = "lastPage"
+}

--- a/app/models/LastPage.scala
+++ b/app/models/LastPage.scala
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package models.requests
+package models
 
-import models.PSAUser
-import play.api.mvc.{Request, WrappedRequest}
-import utils.UserAnswers
+import play.api.libs.json.{Format, Json}
 
-case class OptionalDataRequest[A] (request: Request[A], externalId: String, user: PSAUser,
-                                   userAnswers: Option[UserAnswers]) extends WrappedRequest[A](request) with IdentifiedRequest
+case class LastPage(method: String, url: String)
 
-case class DataRequest[A] (request: Request[A], externalId: String, user: PSAUser,
-                           userAnswers: UserAnswers) extends WrappedRequest[A](request) with IdentifiedRequest
+object LastPage {
+  implicit val formatsLastPage: Format[LastPage] = Json.format[LastPage]
+}

--- a/app/models/requests/AuthenticatedRequest.scala
+++ b/app/models/requests/AuthenticatedRequest.scala
@@ -19,5 +19,9 @@ package models.requests
 import models.PSAUser
 import play.api.mvc.{Request, WrappedRequest}
 
+trait IdentifiedRequest {
+  def externalId: String
+}
+
 case class AuthenticatedRequest[A] (request: Request[A], externalId: String, user: PSAUser) extends
-  WrappedRequest[A](request)
+  WrappedRequest[A](request) with IdentifiedRequest

--- a/app/utils/Navigator2.scala
+++ b/app/utils/Navigator2.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import connectors.DataCacheConnector
+import identifiers.{Identifier, LastPageId}
+import models.requests.IdentifiedRequest
+import models.{CheckMode, LastPage, Mode, NormalMode}
+import play.api.Logger
+import play.api.mvc.Call
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
+import scala.util.Failure
+
+abstract class Navigator2 {
+
+  protected def dataCacheConnector: DataCacheConnector
+
+  protected def routeMap(from: NavigateFrom): Option[NavigateTo]
+
+  protected def editRouteMap(from: NavigateFrom): Option[NavigateTo]
+
+  def nextPage(id: Identifier, mode: Mode, userAnswers: UserAnswers)(implicit ex: IdentifiedRequest, ec: ExecutionContext, hc: HeaderCarrier): Call = {
+    val navigateTo = {
+      mode match {
+        case NormalMode => routeMap(NavigateFrom(id, userAnswers))
+        case CheckMode => editRouteMap(NavigateFrom(id, userAnswers))
+      }
+    }
+
+    navigateTo
+      .map(to => saveAndContinue(to, ex.externalId))
+      .getOrElse(defaultPage(id, mode))
+  }
+
+  private[this] def saveAndContinue(navigation: NavigateTo, externalID: String)(implicit ec: ExecutionContext, hc: HeaderCarrier): Call = {
+    if (navigation.save) {
+      dataCacheConnector.save(externalID, LastPageId, LastPage(navigation.page.method, navigation.page.url)) andThen {
+        case Failure(t: Throwable) => Logger.warn("Error saving user's current page", t)
+      }
+    }
+    navigation.page
+  }
+
+  private[this] def defaultPage(id: Identifier, mode: Mode): Call = {
+    Logger.warn(s"No navigation defined for id $id in mode $mode")
+    controllers.routes.IndexController.onPageLoad()
+  }
+
+  case class NavigateFrom(id: Identifier, userAnswers: UserAnswers)
+
+  case class NavigateTo(page: Call, save: Boolean)
+
+  object NavigateTo {
+    def save(page: Call): Option[NavigateTo] = Some(NavigateTo(page, true))
+    def dontSave(page: Call): Option[NavigateTo] = Some(NavigateTo(page, false))
+  }
+
+}

--- a/app/utils/navigators/IndividualNavigator.scala
+++ b/app/utils/navigators/IndividualNavigator.scala
@@ -17,7 +17,7 @@
 package utils.navigators
 
 import com.google.inject.{Inject, Singleton}
-import identifiers.Identifier
+import identifiers.{Identifier, LastPageId}
 import identifiers.register.individual._
 import play.api.mvc.Call
 import utils.{Navigator, UserAnswers}
@@ -54,7 +54,10 @@ class IndividualNavigator @Inject() extends Navigator {
   def detailsCorrect(answers: UserAnswers): Call = {
     answers.get(IndividualDetailsCorrectId) match {
       case Some(true) =>
-        routes.WhatYouWillNeedController.onPageLoad()
+        answers.get(LastPageId) match {
+          case Some(lastPage) => Call(lastPage.method, lastPage.url)
+          case _ => routes.WhatYouWillNeedController.onPageLoad()
+        }
       case Some(false) =>
         routes.YouWillNeedToUpdateController.onPageLoad()
       case None =>

--- a/app/utils/navigators/RegisterNavigator2.scala
+++ b/app/utils/navigators/RegisterNavigator2.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils.navigators
+
+import connectors.DataCacheConnector
+import identifiers.Identifier
+import identifiers.register.{DeclarationFitAndProperId, DeclarationId, DeclarationWorkingKnowledgeId}
+import javax.inject.Inject
+import models.NormalMode
+import models.register.DeclarationWorkingKnowledge
+import play.api.mvc.Call
+import utils.{Navigator, Navigator2, UserAnswers}
+
+class RegisterNavigator2 @Inject()(val dataCacheConnector: DataCacheConnector) extends Navigator2 {
+
+  override protected def routeMap(from: NavigateFrom): Option[NavigateTo] = from.id match {
+    case DeclarationId => NavigateTo.save(controllers.register.routes.DeclarationWorkingKnowledgeController.onPageLoad(NormalMode))
+    case DeclarationWorkingKnowledgeId =>
+      declarationWorkingKnowledgeRoutes(from.userAnswers)
+    case DeclarationFitAndProperId => NavigateTo.dontSave(controllers.register.routes.ConfirmationController.onPageLoad())
+    case _ => None
+  }
+
+  private def declarationWorkingKnowledgeRoutes(userAnswers: UserAnswers): Option[NavigateTo] = {
+    userAnswers.get(DeclarationWorkingKnowledgeId) match {
+      case Some(DeclarationWorkingKnowledge.WorkingKnowledge) =>
+        NavigateTo.save(controllers.register.routes.DeclarationFitAndProperController.onPageLoad())
+      case Some(DeclarationWorkingKnowledge.Adviser) =>
+        NavigateTo.save(controllers.register.adviser.routes.AdviserDetailsController.onPageLoad(NormalMode))
+      case None =>
+        NavigateTo.dontSave(controllers.routes.SessionExpiredController.onPageLoad())
+    }
+  }
+
+  override protected def editRouteMap(from: NavigateFrom): Option[NavigateTo] = from.id match {
+    case _ => None
+  }
+}

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -41,4 +41,7 @@ trait SpecBase extends PlaySpec with GuiceOneAppPerSuite {
   def fakeRequest = FakeRequest("", "")
 
   implicit def messages: Messages = messagesApi.preferred(fakeRequest)
+
+  def appRunning(): Unit = app
+
 }

--- a/test/connectors/FakeDataCacheConnector.scala
+++ b/test/connectors/FakeDataCacheConnector.scala
@@ -80,6 +80,11 @@ trait FakeDataCacheConnector extends DataCacheConnector with Matchers {
   override def removeAll(cacheId: String)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Result] =
     Future.successful(Ok)
 
+  def reset(): Unit ={
+    data.clear()
+    removed.clear()
+    json = None
+  }
 }
 
 object FakeDataCacheConnector extends FakeDataCacheConnector

--- a/test/controllers/register/DeclarationControllerSpec.scala
+++ b/test/controllers/register/DeclarationControllerSpec.scala
@@ -27,7 +27,7 @@ import models.requests.AuthenticatedRequest
 import play.api.data.Form
 import play.api.mvc.{Call, Request, Result}
 import play.api.test.Helpers._
-import utils.FakeNavigator
+import utils.{FakeNavigator, FakeNavigator2}
 import views.html.register.declaration
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -115,7 +115,7 @@ class DeclarationControllerSpec extends ControllerSpecBase {
 object DeclarationControllerSpec extends ControllerSpecBase {
 
   private val onwardRoute = controllers.routes.IndexController.onPageLoad()
-  private val fakeNavigator = new FakeNavigator(desiredRoute = onwardRoute)
+  private val fakeNavigator = new FakeNavigator2(desiredRoute = onwardRoute)
   private val form: Form[_] = new DeclarationFormProvider()()
   private val companyCancelCall = controllers.register.company.routes.WhatYouWillNeedController.onPageLoad()
   private def fakeAuthAction(userType: UserType) = new AuthAction {

--- a/test/utils/FakeNavigator2.scala
+++ b/test/utils/FakeNavigator2.scala
@@ -16,22 +16,24 @@
 
 package utils
 
-import play.api.mvc.Call
+import connectors.{DataCacheConnector, FakeDataCacheConnector}
 import identifiers.Identifier
 import models.{Mode, NormalMode}
+import play.api.mvc.Call
 
-class FakeNavigator(desiredRoute: Call, mode: Mode = NormalMode) extends Navigator {
+class FakeNavigator2(desiredRoute: Call, mode: Mode = NormalMode) extends Navigator2 {
 
   private[this] var userAnswers: Option[UserAnswers] = None
 
-  override def nextPage(controllerId: Identifier, mode: Mode): (UserAnswers) => Call = {
-    (ua) =>
-      userAnswers = Some(ua)
-      desiredRoute
-  }
-
   def lastUserAnswers: Option[UserAnswers] = userAnswers
 
+  override protected def dataCacheConnector: DataCacheConnector = FakeDataCacheConnector
+
+  override protected def routeMap(from: NavigateFrom): Option[NavigateTo] = NavigateTo.dontSave(desiredRoute)
+
+  override protected def editRouteMap(from: NavigateFrom): Option[NavigateTo] = None
 }
 
-object FakeNavigator extends FakeNavigator(Call("GET", "www.example.com"), NormalMode)
+object FakeNavigator2 extends FakeNavigator2(Call("GET", "www.example.com"), NormalMode){
+
+}

--- a/test/utils/Navigator2Spec.scala
+++ b/test/utils/Navigator2Spec.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import connectors.{DataCacheConnector, FakeDataCacheConnector}
+import identifiers.{LastPageId, TypedIdentifier}
+import models.{CheckMode, LastPage, NormalMode}
+import models.requests.IdentifiedRequest
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.mvc.Call
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class Navigator2Spec extends WordSpec with MustMatchers {
+
+  import Navigator2Spec._
+
+  "Navigator" when {
+
+    "in Normal mode" must {
+      "go to the specified page for an identifier that does exist in the route map" in {
+        val fixture = testFixture()
+        val result = fixture.navigator.nextPage(testExistId, NormalMode, UserAnswers())
+        result mustBe testExistNormalModeCall
+      }
+
+      "go to Index from an identifier that doesn't exist in the route map" in {
+        val fixture = testFixture()
+        val result = fixture.navigator.nextPage(testNotExistId, NormalMode, UserAnswers())
+        result mustBe controllers.routes.IndexController.onPageLoad()
+      }
+    }
+
+    "in Check mode" must {
+      "go to the specified page for an identifier that does exist in the route map" in {
+        val fixture = testFixture()
+        val result = fixture.navigator.nextPage(testExistId, CheckMode, UserAnswers())
+        result mustBe testExistCheckModeCall
+      }
+
+      "go to Index from an identifier that doesn't exist in the edit route map" in {
+        val fixture = testFixture()
+        val result = fixture.navigator.nextPage(testNotExistId, CheckMode, UserAnswers())
+        result mustBe controllers.routes.IndexController.onPageLoad()
+      }
+    }
+
+    "in either mode" must {
+      "save the last page when configured to do so" in {
+        val fixture = testFixture()
+        val result = fixture.navigator.nextPage(testSaveId, NormalMode, UserAnswers())
+        result mustBe testSaveCall
+        fixture.dataCacheConnector.verify(LastPageId, LastPage(testSaveCall.method, testSaveCall.url))
+      }
+
+      "not save the last page when configured not to" in {
+        val fixture = testFixture()
+        val result = fixture.navigator.nextPage(testNotSaveId, NormalMode, UserAnswers())
+        result mustBe testNotSaveCall
+        fixture.dataCacheConnector.verifyNot(LastPageId)
+      }
+    }
+
+  }
+
+}
+
+object Navigator2Spec {
+
+  val testNotExistCall: Call = Call("GET", "http://www.test.com/not-exist")
+  val testExistNormalModeCall: Call = Call("GET", "http://www.test.com/exist/normal-mode")
+  val testExistCheckModeCall: Call = Call("GET", "http://www.test.com/exist/check-mode")
+  val testSaveCall: Call = Call("GET", "http://www.test.com/save")
+  val testNotSaveCall: Call = Call("GET", "http://www.test.com/not-save")
+
+  val testExistId: TypedIdentifier[Nothing] = new TypedIdentifier[Nothing] {}
+  val testNotExistId: TypedIdentifier[Nothing] = new TypedIdentifier[Nothing] {}
+  val testSaveId: TypedIdentifier[Nothing] = new TypedIdentifier[Nothing] {}
+  val testNotSaveId: TypedIdentifier[Nothing] = new TypedIdentifier[Nothing] {}
+
+  class TestNavigator(val dataCacheConnector: DataCacheConnector) extends Navigator2 {
+
+    override protected def routeMap(from: NavigateFrom): Option[NavigateTo] =
+      from.id match {
+        case `testExistId` => NavigateTo.dontSave(testExistNormalModeCall)
+        case `testSaveId` => NavigateTo.save(testSaveCall)
+        case `testNotSaveId` => NavigateTo.dontSave(testNotSaveCall)
+        case _ => None
+      }
+
+    override protected def editRouteMap(from: NavigateFrom): Option[NavigateTo] =
+      from.id match {
+        case `testExistId` => NavigateTo.dontSave(testExistCheckModeCall)
+        case _ => None
+      }
+
+  }
+
+  trait TestFixture {
+    def dataCacheConnector: FakeDataCacheConnector
+    def navigator: TestNavigator
+  }
+
+  def testFixture(): TestFixture = new TestFixture {
+    override val dataCacheConnector: FakeDataCacheConnector = new FakeDataCacheConnector {}
+    override val navigator: TestNavigator = new TestNavigator(dataCacheConnector)
+  }
+
+  implicit val ex: IdentifiedRequest = new IdentifiedRequest() {val externalId: String = "test-external-id"}
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+}

--- a/test/utils/NavigatorBehaviour2.scala
+++ b/test/utils/NavigatorBehaviour2.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import connectors.FakeDataCacheConnector
+import identifiers.{Identifier, LastPageId}
+import models.requests.IdentifiedRequest
+import models.{CheckMode, LastPage, NormalMode}
+import org.scalatest.prop.{PropertyChecks, TableFor6}
+import org.scalatest.{MustMatchers, OptionValues, WordSpec}
+import play.api.mvc.Call
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
+
+trait NavigatorBehaviour2 extends PropertyChecks with OptionValues {
+  this: WordSpec with MustMatchers =>
+
+  def navigatorWithRoutes[A <: Identifier](navigator: Navigator2,
+                                           dataCacheConnector: FakeDataCacheConnector,
+                                           routes: TableFor6[A, UserAnswers, Call, Boolean, Option[Call], Boolean])
+                                          (implicit ex: IdentifiedRequest, ec: ExecutionContext, hc: HeaderCarrier): Unit = {
+
+    "behave like a navigator" when {
+
+      "navigating in NormalMode" must {
+        forAll(routes) {
+          (id: Identifier, userAnswers: UserAnswers, call: Call, save: Boolean, _: Option[Call], _: Boolean) =>
+            s"move from $id to $call when data is $userAnswers" in {
+              val result = navigator.nextPage(id, NormalMode, userAnswers)
+              result mustBe call
+            }
+
+            s"move from $id to $call and ${if (!save) "not "}save the page" in {
+              dataCacheConnector.reset()
+              navigator.nextPage(id, NormalMode, userAnswers)
+              if (save) {
+                dataCacheConnector.verify(LastPageId, LastPage(call.method, call.url))
+              }
+              else {
+                dataCacheConnector.verifyNot(LastPageId)
+              }
+            }
+        }
+      }
+
+      "navigating in CheckMode" must {
+        forAll(routes) { (id: Identifier, userAnswers: UserAnswers, _: Call, _: Boolean, editCall: Option[Call], save: Boolean) =>
+          if (editCall.isDefined) {
+            s"move from $id to ${editCall.value} when data is $userAnswers" in {
+              val result = navigator.nextPage(id, CheckMode, userAnswers)
+              result mustBe editCall.value
+            }
+
+            s"move from $id to $editCall and ${if (!save) "not "}save the page" in {
+              dataCacheConnector.reset()
+              navigator.nextPage(id, CheckMode, userAnswers)
+              if (save) {
+                dataCacheConnector.verify(LastPageId, LastPage(editCall.value.method, editCall.value.url))
+              }
+              else {
+                dataCacheConnector.verifyNot(LastPageId)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def nonMatchingNavigator(navigator: Navigator2)(implicit ex: IdentifiedRequest, ec: ExecutionContext, hc: HeaderCarrier): Unit = {
+
+    val testId: Identifier = new Identifier {}
+
+    "behaviour like a navigator without routes" when {
+      "navigating in NormalMode" must {
+        "return a call given a non-configured Id" in {
+          navigator.nextPage(testId, NormalMode, UserAnswers()) mustBe a[Call]
+        }
+      }
+
+      "navigating in CheckMode" must {
+        "return a call given a non-configured Id" in {
+          navigator.nextPage(testId, CheckMode, UserAnswers()) mustBe a[Call]
+        }
+      }
+    }
+
+  }
+
+}

--- a/test/utils/navigators/NavigatorBehaviour.scala
+++ b/test/utils/navigators/NavigatorBehaviour.scala
@@ -20,7 +20,7 @@ import identifiers.Identifier
 import models.{CheckMode, NormalMode}
 import org.scalatest.{MustMatchers, OptionValues, WordSpec}
 import org.scalatest.prop.{PropertyChecks, TableFor4}
-import play.api.mvc.Call
+import play.api.mvc.{Call, Request}
 import utils.{Navigator, UserAnswers}
 
 trait NavigatorBehaviour extends PropertyChecks with OptionValues {
@@ -51,4 +51,25 @@ trait NavigatorBehaviour extends PropertyChecks with OptionValues {
       }
     }
   }
+
+  def nonMatchingNavigator(navigator: Navigator): Unit = {
+
+    val testId: Identifier = new Identifier {}
+
+    "behaviour like a navigator without routes" when {
+      "navigating in NormalMode" must {
+        "return a call given a non-configured Id" in {
+          navigator.nextPage(testId, NormalMode)(UserAnswers()) mustBe a[Call]
+        }
+      }
+
+      "navigating in CheckMode" must {
+        "return a call given a non-configured Id" in {
+          navigator.nextPage(testId, CheckMode)(UserAnswers()) mustBe a[Call]
+        }
+      }
+    }
+
+  }
+
 }

--- a/test/utils/navigators/RegisterNavigatorSpec2.scala
+++ b/test/utils/navigators/RegisterNavigatorSpec2.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils.navigators
+
+import base.SpecBase
+import connectors.FakeDataCacheConnector
+import controllers.register.routes
+import identifiers.Identifier
+import identifiers.register.{DeclarationFitAndProperId, DeclarationId, DeclarationWorkingKnowledgeId}
+import models.NormalMode
+import models.register.DeclarationWorkingKnowledge
+import models.requests.IdentifiedRequest
+import org.scalatest.OptionValues
+import org.scalatest.prop.TableFor6
+import play.api.libs.json.Json
+import play.api.mvc.Call
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.{NavigatorBehaviour2, UserAnswers}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RegisterNavigatorSpec2 extends SpecBase with NavigatorBehaviour2 {
+  import RegisterNavigatorSpec2._
+  val navigator = new RegisterNavigator2(FakeDataCacheConnector)
+
+  //scalastyle:off line.size.limit
+  def routes(): TableFor6[Identifier, UserAnswers, Call, Boolean, Option[Call], Boolean] = Table(
+    ("Id",                          "User Answers",                  "Next Page (Normal Mode)",       "Save(NormalMode)",  "Next Page (Check Mode)", "Save(CheckMode"),
+    (DeclarationId,                 emptyAnswers,                    declarationWorkingKnowledgePage, true,                None,                     false),
+    (DeclarationWorkingKnowledgeId, haveDeclarationWorkingKnowledge, declarationFitAndProperPage,     true,                None,                     false),
+    (DeclarationWorkingKnowledgeId, haveAnAdviser,                   adviserDetailsPage,              true,                None,                     false),
+    (DeclarationWorkingKnowledgeId, emptyAnswers,                    sessionExpiredPage,              false,               None,                     false),
+    (DeclarationFitAndProperId,     emptyAnswers,                    confirmationPage,                false,               None,                     false)
+  )
+  //scalastyle:on line.size.limit
+
+  navigator.getClass.getSimpleName must {
+    appRunning()
+    behave like nonMatchingNavigator(navigator)
+    behave like navigatorWithRoutes(navigator, FakeDataCacheConnector, routes())
+  }
+
+}
+
+object RegisterNavigatorSpec2 extends OptionValues {
+  lazy val emptyAnswers = UserAnswers(Json.obj())
+  lazy val sessionExpiredPage: Call = controllers.routes.SessionExpiredController.onPageLoad()
+  lazy val declarationWorkingKnowledgePage: Call = routes.DeclarationWorkingKnowledgeController.onPageLoad(NormalMode)
+  lazy val declarationFitAndProperPage: Call = routes.DeclarationFitAndProperController.onPageLoad()
+  lazy val adviserDetailsPage: Call = controllers.register.adviser.routes.AdviserDetailsController.onPageLoad(NormalMode)
+  lazy val confirmationPage: Call = routes.ConfirmationController.onPageLoad()
+  lazy val surveyPage: Call = controllers.routes.LogoutController.onPageLoad()
+
+  val haveDeclarationWorkingKnowledge: UserAnswers = UserAnswers(Json.obj())
+    .set(DeclarationWorkingKnowledgeId)(DeclarationWorkingKnowledge.WorkingKnowledge).asOpt.value
+  val haveAnAdviser: UserAnswers = UserAnswers(Json.obj())
+    .set(DeclarationWorkingKnowledgeId)(DeclarationWorkingKnowledge.Adviser).asOpt.value
+
+  implicit val ex: IdentifiedRequest = new IdentifiedRequest() {val externalId: String = "test-external-id"}
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+}

--- a/test/utils/package.scala
+++ b/test/utils/package.scala
@@ -15,16 +15,21 @@
  */
 
 import controllers.actions.{DataRetrievalAction, FakeDataRetrievalAction}
+import identifiers.LastPageId
 import identifiers.register.adviser.{AdviserAddressId, AdviserAddressListId}
 import identifiers.register.company.directors.{CompanyDirectorAddressListId, DirectorAddressId, DirectorPreviousAddressId, DirectorPreviousAddressListId}
 import identifiers.register.company.{CompanyAddressListId, CompanyPreviousAddressId}
-import identifiers.register.individual.{IndividualContactAddressId, IndividualContactAddressListId, IndividualPreviousAddressId, IndividualPreviousAddressListId}
-import models.{Address, TolerantAddress}
+import identifiers.register.individual._
+import models.{Address, LastPage, TolerantAddress}
 import org.scalatest.OptionValues
 
 package object utils {
 
   implicit class UserAnswerOps(answers: UserAnswers) extends OptionValues {
+
+    def lastPage(page: LastPage): UserAnswers = {
+      answers.set(LastPageId)(page).asOpt.value
+    }
 
     // Individual PSA Contact
     def individualContactAddress(address: Address): UserAnswers = {


### PR DESCRIPTION
Myself and @PaulCDurham are building the new navigtors alongside the existing ones and then will remove and refactor when all are completed and moved over. 

For now, the register navigator has been moved to the new type and we have made the individual journey return the user to the last page they were on when they log back in.