### PR TITLE
PODS-9192: Changed unauth route use case

### DIFF
--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -147,7 +147,7 @@ protected class FullAuthentication @Inject()(override val authConnector: AuthCon
       Redirect(routes.UnauthorisedController.onPageLoad)
     case _: InsufficientConfidenceLevel =>
       val completionURL = RedirectUrl(request.uri)
-      val failureURL = RedirectUrl(s"${config.loginContinueUrlRelative}/unauthorised")
+      val failureURL = RedirectUrl(controllers.routes.UnauthorisedController.onPageLoad.url)
       val url = config.identityValidationFrontEndEntry(completionURL, failureURL)
       SeeOther(url)
     case _: UnsupportedAuthProvider =>


### PR DESCRIPTION
Small change to the way IV journey is enforced. Behaviour should be the same.